### PR TITLE
[UI Component] Bug with `id_prefix` reference in `nav-secondary`

### DIFF
--- a/src/components/08-navigation/_nav-secondary.njk
+++ b/src/components/08-navigation/_nav-secondary.njk
@@ -7,6 +7,6 @@
     {%- endfor -%}
   </ul>
   {%- if nav.search -%}
-    {% render '@search--header', {search: nav.search, search_js: false, id_prefix: id_prefix} %}
+    {% render '@search--header', {search: nav.search, search_js: false, id_prefix: nav.id_prefix} %}
   {%- endif -%}
 </div>


### PR DESCRIPTION
## Description

It appears that with https://github.com/uswds/uswds/commit/7684b727ae99f4bd098703cc8b0754c8f4a3c785#diff-239d88ed4b05e67187a5f64a0e9653a5 a bug has been introduced where `id_prefix` is never going to be passed down to the `search--header` template.

